### PR TITLE
Stop logging cache-init JSON parse errors + fix SSR build break

### DIFF
--- a/data/utils.ts
+++ b/data/utils.ts
@@ -48,25 +48,34 @@ export const tryCatchPromise = (dispatch: Dispatch<any>, funcArgs?: any[]) => as
 }
 
 export function loadStateFromCache<T>(cacheKey: CacheKey, fallbackState: T): T {
+  if (typeof window === 'undefined') {
+    return fallbackState
+  }
+  const stateCachedStr = window.localStorage.getItem(cacheKey)
+  if (!stateCachedStr) {
+    return fallbackState
+  }
   try {
-    // add empty string fallback so JSON.parse() fails, JSON.parse(null) will actually succeed + return null
-    const stateCachedStr = localStorage.getItem(cacheKey) || '' 
-    // catch will stop crash, and logic will fallthrough to return boostersInitialState if parse fails
-    const stateCached = JSON.parse(stateCachedStr as string)  
-    return stateCached
+    return JSON.parse(stateCachedStr)
   } catch(error) {
     console.log(`Error: Was not able to initialize '${cacheKey}' from cache. ${error}`)
+    return fallbackState
   }
-  return fallbackState
 }
 
 export function setCache(cacheKey: CacheKey, state: any) {
+  if (typeof window === 'undefined') {
+    return
+  }
   try {
-    localStorage.setItem(cacheKey, JSON.stringify(state))
+    window.localStorage.setItem(cacheKey, JSON.stringify(state))
   } catch(error) {
     console.log(`Error: Could not set cache '${cacheKey}'. ${error}`)
   }
 }
 export function clearCache(cacheKey: CacheKey) {
-  localStorage.removeItem(cacheKey)
+  if (typeof window === 'undefined') {
+    return
+  }
+  window.localStorage.removeItem(cacheKey)
 }


### PR DESCRIPTION
## Diagnosis

The console errors reported at https://yugiohdrafter.com come from two unrelated sources.

### 1. CORS-blocked unpkg scripts — **deployment artifact, not in this repo**

The live `https://yugiohdrafter.com` HTML is still the **old Create React App build**, not the Next.js code that has been on `master` since the nextjs migration merged. The old `public/index.html` (deleted in commit 4a63dd1) hardcoded these scripts:

```html
<script src="https://unpkg.com/react/umd/react.production.min.js" crossorigin></script>
<script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js" crossorigin></script>
<script src="https://unpkg.com/react-bootstrap@next/dist/react-bootstrap.min.js" crossorigin></script>
```

unpkg now 302-redirects each of those URLs to the latest version (`react@19.2.6`, `react-bootstrap@3.0.0-beta.5`, etc.), and **React 19 dropped its UMD build entirely** — so the redirect target 404s. Chrome surfaces this as a CORS error because the 404 response has no `Access-Control-Allow-Origin` header.

The current Next.js code on `master` references none of these scripts. Verified with `grep -ri unpkg`, `grep -ri react-bootstrap`, etc. → 0 matches. **The only fix for the unpkg errors is to redeploy the Next.js build to the AWS S3 bucket** that backs `yugiohdrafter.com`. This PR does not include deployment infra changes because the AWS-side hosting setup (Amplify vs. S3+CloudFront vs. App Runner) isn't represented in the repo and a wrong guess would cause more harm than good.

### 2. `JSON.parse('') → Unexpected end of JSON input` warnings — **fixed in this PR**

`data/utils.ts` `loadStateFromCache` was doing:
```ts
const stateCachedStr = localStorage.getItem(cacheKey) || ''
const stateCached = JSON.parse(stateCachedStr as string)
```
When the cache key isn't set (first visit, cleared storage), `getItem` returns `null` → coerced to `''` → `JSON.parse('')` throws → catch logs `"Error: Was not able to initialize 'yugiohdrafter.com-cards' from cache. SyntaxError…"`. This noise hits the console on every first-visit pageload even though the empty case is the expected path.

Also discovered while running `next build`: this same function is called at module-eval time from `data/cards/reducer.ts` and `data/deck/reducer.ts`. On the Next.js server runtime there's no `localStorage`, so `next build` was failing with:

```
ReferenceError: localStorage is not defined
    at loadStateFromCache (.next/server/chunks/550.js:837:28)
    ...
```

Confirmed against `master` — the production build is broken there too, this isn't a regression I introduced.

## Fix

`data/utils.ts`: in all three cache helpers, bail out early when `typeof window === 'undefined'` (SSR), and in `loadStateFromCache` short-circuit before `JSON.parse` when the stored value is `null` or empty. Only log on the genuinely-broken case (non-empty value that fails to parse).

## Verification

Local prod build of this branch, captured in browser:
- `npm install && npm run build && npx next start -p 3010`
- Visit http://localhost:3010 → 0 console errors, 0 `unpkg` references, 0 `Was not able to initialize` warnings, page renders normally. (One unrelated `GET /api/cardSets 500` from missing local MongoDB credentials, present on the live site too.)

Same negative result for `npm run dev` at http://localhost:3002.

Live `https://yugiohdrafter.com` still shows all three unpkg CORS errors + both cache-init warnings — confirms the live site is the stale CRA build.

## Required follow-up (outside this PR)

To make the unpkg CORS errors actually go away from the production URL: redeploy this branch's `next build` output to the AWS bucket / hosting that serves `yugiohdrafter.com`.

## Test plan
- [x] `npm run build` completes (was failing on `master` due to SSR localStorage reference)
- [x] `npx next start -p 3010` serves the homepage with no console errors related to unpkg or cache init
- [x] `npm run dev` (port 3002) renders the homepage with no cache-init warnings
- [ ] Reviewer opens http://localhost:3010 after `npm install && npm run build && npx next start -p 3010` and confirms a clean console